### PR TITLE
Fix: weather service interface result model

### DIFF
--- a/internal/domain/weather.go
+++ b/internal/domain/weather.go
@@ -9,5 +9,5 @@ import (
 )
 
 type WeatherService interface {
-	GetWeatherSummary(ctx context.Context, lat string, lon string) (*model.Weather, error)
+	GetWeatherSummary(ctx context.Context, lat string, lon string) (*model.WeatherResult, error)
 }


### PR DESCRIPTION
## What?

지난 #4 번에서 같이 수정되지 못한 커밋을 반영한다.
- weather service의 interface에서 반환형 수정이 weather에서 weatherResult로 변경되었는데, 반영을 하지 못했다.

## How?

이름을 변경한다.

## Anything Else?