### PR TITLE
Add: weather handler validation

### DIFF
--- a/internal/controller/weather_test.go
+++ b/internal/controller/weather_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,31 +9,33 @@ import (
 	// external packages
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	// project packages
-	"github.com/closetotheworld/go-weather-service/internal/service"
+	"github.com/closetotheworld/go-weather-service/internal/model"
+	"github.com/closetotheworld/go-weather-service/internal/service/weather"
 )
 
 func TestNewWeatherHeandler(t *testing.T) {
-	mockWeatherManager := service.NewMockWeatherService()
+	mockWeatherManager := weather.NewMockWeatherService(t)
 	s := NewWeatherHeandler(mockWeatherManager)
-	assert.Equal(t, s, WeatherHandler{})
+	assert.NotNil(t, s)
 }
 
 func TestWeatherHandler_GetWeatherSummary(t *testing.T) {
-	w := NewWeatherHeandler(service.NewMockWeatherService())
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-
-	r := gin.Default()
-	r.GET("/summary", w.GetWeatherSummary)
-
+	//c, _ := gin.CreateTestContext()
 	// handler test를 위한 func variable
-	testHandlerFunc := func(engine *gin.Engine, lat string, lon string) *httptest.ResponseRecorder {
+	testHandlerFunc := func(engine *gin.Engine, lat *string, lon *string) *httptest.ResponseRecorder {
 		httpRequest, _ := http.NewRequest(http.MethodGet, "/summary", nil)
 
 		q := httpRequest.URL.Query()
-		q.Add("lat", lat)
-		q.Add("lon", lon)
+		if lat != nil {
+			q.Add("lat", *lat)
+		}
+		if lon != nil {
+			q.Add("lon", *lon)
+		}
+
 		httpRequest.URL.RawQuery = q.Encode()
 
 		w := httptest.NewRecorder()
@@ -42,15 +45,68 @@ func TestWeatherHandler_GetWeatherSummary(t *testing.T) {
 
 	// valid param test
 	t.Run("test valid param", func(t *testing.T) {
-		res := testHandlerFunc(r, "-45", "-45")
-		w.GetWeatherSummary(c)
+		mockWeatherService := weather.NewMockWeatherService(t)
+		w := NewWeatherHeandler(mockWeatherService)
+		mockResult := model.WeatherResult{
+			Summary: model.Weather{
+				Greeting:   "mockGreeting",
+				Temperture: "mockTemperture",
+				HeadsUp:    "mockHeadsUp",
+			},
+		}
+		mockWeatherService.On("GetWeatherSummary", mock.Anything, mock.Anything, mock.Anything).Return(&mockResult, nil)
+
+		r := gin.Default()
+		r.GET("/summary", w.GetWeatherSummary)
+
+		lat := "-45"
+		lon := "-45"
+
+		res := testHandlerFunc(r, &lat, &lon)
 		assert.Equal(t, http.StatusOK, res.Code)
+		assert.NotNil(t, res.Body)
 	})
 
 	// invalid param test
 	t.Run("test invalid param", func(t *testing.T) {
-		res := testHandlerFunc(r, "-180", "-45")
-		w.GetWeatherSummary(c)
-		assert.Equal(t, http.StatusBadRequest, res.Code)
+		t.Run("invalid param(out of range)", func(t *testing.T) {
+			mockWeatherService := weather.NewMockWeatherService(t)
+			w := NewWeatherHeandler(mockWeatherService)
+
+			r := gin.Default()
+			r.GET("/summary", w.GetWeatherSummary)
+
+			lat := "-100"
+			lon := "-120"
+
+			res := testHandlerFunc(r, &lat, &lon)
+			assert.Equal(t, http.StatusBadRequest, res.Code)
+		})
+		t.Run("invalid param(not add query param)", func(t *testing.T) {
+			mockWeatherService := weather.NewMockWeatherService(t)
+			w := NewWeatherHeandler(mockWeatherService)
+
+			r := gin.Default()
+			r.GET("/summary", w.GetWeatherSummary)
+
+			res := testHandlerFunc(r, nil, nil)
+			assert.Equal(t, http.StatusBadRequest, res.Code)
+		})
+
+	})
+
+	t.Run("internal server error (service or pkg api occured error)", func(t *testing.T) {
+		mockWeatherService := weather.NewMockWeatherService(t)
+		w := NewWeatherHeandler(mockWeatherService)
+		mockWeatherService.On("GetWeatherSummary", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("some error"))
+
+		r := gin.Default()
+		r.GET("/summary", w.GetWeatherSummary)
+
+		lat := "-45"
+		lon := "-45"
+
+		res := testHandlerFunc(r, &lat, &lon)
+		assert.Equal(t, http.StatusInternalServerError, res.Code)
 	})
 }

--- a/internal/domain/weather.go
+++ b/internal/domain/weather.go
@@ -9,5 +9,5 @@ import (
 )
 
 type WeatherService interface {
-	GetWeatherSummary(ctx context.Context, lat string, lon string) (*model.WeatherResult, error)
+	GetWeatherSummary(ctx context.Context, lat float32, lon float32) (*model.WeatherResult, error)
 }

--- a/internal/service/weather/mock_test_case.go
+++ b/internal/service/weather/mock_test_case.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	forecastHourOffset   = []string{"6", "12", "18", "24", "30", "36", "42", "48"}
-	historicalHourOffset = []string{"-6", "-12", "-18", "-24"}
+	forecastHourOffset   = []int{6, 12, 18, 24, 30, 36, 42, 48}
+	historicalHourOffset = []int{-6, -12, -18, -24}
 )
 
 type WeatherCase struct {
@@ -69,7 +69,7 @@ func (w *WeatherCase) CreateForTestHistorical() {
 		})
 	}
 	for j := range historicalHourOffset {
-		if historicalHourOffset[j] == "-24" {
+		if historicalHourOffset[j] == -24 {
 			break
 		}
 		w.Historical = append(w.Historical, &weather_api.WeatherApiCommon{
@@ -121,25 +121,25 @@ func GetTempertureTestCase(caseNum int) (*WeatherCase, string) {
 
 	switch caseNum {
 	case 0:
-		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 30.5, HourOffset: "-24"})
+		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 30.5, HourOffset: -24})
 		answer = celsiusLowerOver(10)
 	case 1:
 		wc.Current.Temp = 10.5
-		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 20.5, HourOffset: "-24"})
+		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 20.5, HourOffset: -24})
 		answer = celsiusLowerUnder(10)
 	case 2:
-		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 10.5, HourOffset: "-24"})
+		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 10.5, HourOffset: -24})
 		answer = celsiusUpperOver(10)
 	case 3:
 		wc.Current.Temp = 10.5
-		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 0.5, HourOffset: "-24"})
+		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 0.5, HourOffset: -24})
 		answer = celsiusUpperUnder(10)
 	case 4:
-		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 20.5, HourOffset: "-24"})
+		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 20.5, HourOffset: -24})
 		answer = celsiusSame(wc.Current.Temp)
 	case 5:
 		wc.Current.Temp = 10.5
-		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 10.5, HourOffset: "-24"})
+		wc.Historical = append(wc.Historical, &weather_api.WeatherApiCommon{Temp: 10.5, HourOffset: -24})
 		answer = celsiusSame(wc.Current.Temp)
 	}
 	if caseNum == 0 {

--- a/internal/service/weather/parse.go
+++ b/internal/service/weather/parse.go
@@ -1,7 +1,6 @@
 package weather
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -104,7 +103,6 @@ func ParseHeadsUp(forecastWeather []*weather_api.WeatherApiForecast) string {
 		return fw[i].HourOffset < fw[j].HourOffset
 	})
 	for i := range fw {
-		fmt.Println(fw[i].HourOffset)
 		mapWeather[fw[i].Code] += 6
 		if fw[i].HourOffset == 24 {
 			if mapWeather[CODE_SNOWY] >= 12 {

--- a/internal/service/weather/parse.go
+++ b/internal/service/weather/parse.go
@@ -53,7 +53,7 @@ func ParseTemperture(currentTemp float32, historicalWeather []*weather_api.Weath
 	answer := ""
 
 	for i := range historicalWeather {
-		if historicalWeather[i].HourOffset == "-24" {
+		if historicalWeather[i].HourOffset == -24 {
 			yDayTemp = historicalWeather[i].Temp
 		}
 
@@ -106,7 +106,7 @@ func ParseHeadsUp(forecastWeather []*weather_api.WeatherApiForecast) string {
 	for i := range fw {
 		fmt.Println(fw[i].HourOffset)
 		mapWeather[fw[i].Code] += 6
-		if fw[i].HourOffset == "24" {
+		if fw[i].HourOffset == 24 {
 			if mapWeather[CODE_SNOWY] >= 12 {
 				answer = WEATHER_EXPECT_HEAVY_SNOW
 				return answer

--- a/internal/service/weather/weather.go
+++ b/internal/service/weather/weather.go
@@ -21,7 +21,7 @@ func NewWeatherService(wm weather_api.WeatherApiManager) domain.WeatherService {
 	return &WeatherService{WeatherApiManager: wm}
 }
 
-func (w *WeatherService) GetWeatherSummary(ctx context.Context, lat string, lon string) (*model.WeatherResult, error) {
+func (w *WeatherService) GetWeatherSummary(ctx context.Context, lat float32, lon float32) (*model.WeatherResult, error) {
 	current, forecast, historical, err := w.WeatherApiManager.AsyncRequest(lat, lon)
 	if err != nil {
 		return nil, e.ErrorByStatus(http.StatusInternalServerError)

--- a/pkg/weather_api/mock_weather_api_manager.go
+++ b/pkg/weather_api/mock_weather_api_manager.go
@@ -10,11 +10,11 @@ type MockWeatherApiManager struct {
 }
 
 // AsyncRequest provides a mock function with given fields: lat, lon
-func (_m *MockWeatherApiManager) AsyncRequest(lat string, lon string) (*WeatherApiCommon, []*WeatherApiForecast, []*WeatherApiCommon, error) {
+func (_m *MockWeatherApiManager) AsyncRequest(lat float32, lon float32) (*WeatherApiCommon, []*WeatherApiForecast, []*WeatherApiCommon, error) {
 	ret := _m.Called(lat, lon)
 
 	var r0 *WeatherApiCommon
-	if rf, ok := ret.Get(0).(func(string, string) *WeatherApiCommon); ok {
+	if rf, ok := ret.Get(0).(func(float32, float32) *WeatherApiCommon); ok {
 		r0 = rf(lat, lon)
 	} else {
 		if ret.Get(0) != nil {
@@ -23,7 +23,7 @@ func (_m *MockWeatherApiManager) AsyncRequest(lat string, lon string) (*WeatherA
 	}
 
 	var r1 []*WeatherApiForecast
-	if rf, ok := ret.Get(1).(func(string, string) []*WeatherApiForecast); ok {
+	if rf, ok := ret.Get(1).(func(float32, float32) []*WeatherApiForecast); ok {
 		r1 = rf(lat, lon)
 	} else {
 		if ret.Get(1) != nil {
@@ -32,7 +32,7 @@ func (_m *MockWeatherApiManager) AsyncRequest(lat string, lon string) (*WeatherA
 	}
 
 	var r2 []*WeatherApiCommon
-	if rf, ok := ret.Get(2).(func(string, string) []*WeatherApiCommon); ok {
+	if rf, ok := ret.Get(2).(func(float32, float32) []*WeatherApiCommon); ok {
 		r2 = rf(lat, lon)
 	} else {
 		if ret.Get(2) != nil {
@@ -41,7 +41,7 @@ func (_m *MockWeatherApiManager) AsyncRequest(lat string, lon string) (*WeatherA
 	}
 
 	var r3 error
-	if rf, ok := ret.Get(3).(func(string, string) error); ok {
+	if rf, ok := ret.Get(3).(func(float32, float32) error); ok {
 		r3 = rf(lat, lon)
 	} else {
 		r3 = ret.Error(3)

--- a/pkg/weather_api/weather_test.go
+++ b/pkg/weather_api/weather_test.go
@@ -13,20 +13,20 @@ var (
 func TestWeatherApiManagerImpl_GetCurrentInfo(t *testing.T) {
 	t.Run("test valid request", func(t *testing.T) {
 		w.ApiKey = API_KEY
-		result, err := w.GetCurrentInfo("10", "-120")
+		result, err := w.GetCurrentInfo(10, -120)
 		assert.NotNil(t, result)
 		assert.Nil(t, err, nil)
 		t.Log(result)
 	})
 	t.Run("test bad request", func(t *testing.T) {
 		w.ApiKey = API_KEY
-		result, err := w.GetCurrentInfo("-100", "-200")
+		result, err := w.GetCurrentInfo(-100, -200)
 		assert.Nil(t, result)
 		assert.NotNil(t, err)
 	})
 	t.Run("test unauthrized", func(t *testing.T) {
 		w.ApiKey = ""
-		_, err := w.GetCurrentInfo("-100", "-200")
+		_, err := w.GetCurrentInfo(-100, -200)
 		assert.NotNil(t, err)
 	})
 }
@@ -34,20 +34,20 @@ func TestWeatherApiManagerImpl_GetCurrentInfo(t *testing.T) {
 func TestWeatherApiManagerImpl_GetForecastInfo(t *testing.T) {
 	t.Run("test valid request", func(t *testing.T) {
 		w.ApiKey = API_KEY
-		result, err := w.GetForecastInfo("10", "-120", "12")
+		result, err := w.GetForecastInfo(10, -120, 12)
 		t.Log(result)
 		assert.NotNil(t, result)
 		assert.Nil(t, err, nil)
 	})
 	t.Run("test bad request", func(t *testing.T) {
 		w.ApiKey = API_KEY
-		result, err := w.GetForecastInfo("-100", "-200", "5")
+		result, err := w.GetForecastInfo(-100, -200, 12)
 		assert.Nil(t, result)
 		assert.NotNil(t, err)
 	})
 	t.Run("test unauthorized", func(t *testing.T) {
 		w.ApiKey = ""
-		_, err := w.GetForecastInfo("-100", "-200", "16")
+		_, err := w.GetForecastInfo(-100, -200, 12)
 		assert.NotEqual(t, err, nil)
 	})
 }
@@ -55,19 +55,19 @@ func TestWeatherApiManagerImpl_GetForecastInfo(t *testing.T) {
 func TestWeatherApiManagerImpl_GetHistoricalInfo(t *testing.T) {
 	t.Run("test valid request", func(t *testing.T) {
 		w.ApiKey = API_KEY
-		result, err := w.GetHistoricalInfo("10", "-120", "-6")
+		result, err := w.GetHistoricalInfo(10, -120, -6)
 		t.Log(result)
 		assert.NotNil(t, result)
 		assert.Nil(t, err, nil)
 	})
 	t.Run("test bad request", func(t *testing.T) {
 		w.ApiKey = API_KEY
-		result, err := w.GetHistoricalInfo("-100", "-200", "-10")
+		result, err := w.GetHistoricalInfo(-100, -200, -10)
 		assert.Nil(t, result)
 		assert.NotNil(t, err)
 	})
 	t.Run("test unauthorized", func(t *testing.T) {
-		_, err := w.GetHistoricalInfo("-100", "-200", "2")
+		_, err := w.GetHistoricalInfo(-100, -200, 2)
 		assert.NotEqual(t, err, nil)
 	})
 }
@@ -75,7 +75,7 @@ func TestWeatherApiManagerImpl_GetHistoricalInfo(t *testing.T) {
 func TestWeatherApiManagerImpl_AsyncRequest(t *testing.T) {
 	t.Run("run", func(t *testing.T) {
 		w.ApiKey = API_KEY
-		current, forecast, historical, err := w.AsyncRequest("10", "-120")
+		current, forecast, historical, err := w.AsyncRequest(10, -120)
 		t.Log(current)
 		for i := range forecast {
 			t.Log(forecast[i])


### PR DESCRIPTION
## What?

input query에 대한 validation을 추가한다.

## How?

1. handler test를 작성한다.
    - 200OK test
    - 400 Bad request test
    - 500 internal server test
2. handler에 validate를 추가한다.

## Anything Else?

query variable은 string으로 사용되는 떄가 외부 api 요청 시 query param 추가를 할 때 인데, 그 전에 변경하여 사용하는 것은 타입추론이 불분명하므로 string 변환은 필요한 함수에서 하도록 변환하고 기본 type을 float32로 변경했다. 752dc73cbaff8d982fe98ffb1aba61c284abea90